### PR TITLE
Adding onTrimStarted listener, Fixing FC if OnTrimVideoListener is not set.

### DIFF
--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
@@ -276,6 +276,9 @@ public class K4LVideoTrimmer extends FrameLayout {
                 }
             }
 
+            //notify that video trimming started
+            mOnTrimVideoListener.onTrimStarted();
+
             BackgroundExecutor.execute(
                     new BackgroundExecutor.Task("", 0L, "") {
                         @Override

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
@@ -169,7 +169,8 @@ public class K4LVideoTrimmer extends FrameLayout {
         mVideoView.setOnErrorListener(new MediaPlayer.OnErrorListener() {
             @Override
             public boolean onError(MediaPlayer mediaPlayer, int what, int extra) {
-                mOnTrimVideoListener.onError("Something went wrong reason : " + what);
+                if (mOnTrimVideoListener != null)
+                    mOnTrimVideoListener.onError("Something went wrong reason : " + what);
                 return false;
             }
         });
@@ -256,7 +257,8 @@ public class K4LVideoTrimmer extends FrameLayout {
 
     private void onSaveClicked() {
         if (mStartPosition <= 0 && mEndPosition >= mDuration) {
-            mOnTrimVideoListener.getResult(mSrc);
+            if (mOnTrimVideoListener != null)
+                mOnTrimVideoListener.getResult(mSrc);
         } else {
             mPlayView.setVisibility(View.VISIBLE);
             mVideoView.pause();
@@ -277,7 +279,8 @@ public class K4LVideoTrimmer extends FrameLayout {
             }
 
             //notify that video trimming started
-            mOnTrimVideoListener.onTrimStarted();
+            if (mOnTrimVideoListener != null)
+                mOnTrimVideoListener.onTrimStarted();
 
             BackgroundExecutor.execute(
                     new BackgroundExecutor.Task("", 0L, "") {

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/interfaces/OnTrimVideoListener.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/interfaces/OnTrimVideoListener.java
@@ -27,6 +27,8 @@ import android.net.Uri;
 
 public interface OnTrimVideoListener {
 
+    void onTrimStarted();
+
     void getResult(final Uri uri);
 
     void cancelAction();

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/utils/TrimVideoUtils.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/utils/TrimVideoUtils.java
@@ -137,7 +137,8 @@ public class TrimVideoUtils {
 
         fc.close();
         fos.close();
-        callback.getResult(Uri.parse(dst.toString()));
+        if (callback != null)
+            callback.getResult(Uri.parse(dst.toString()));
     }
 
     private static double correctTimeToSyncSample(@NonNull Track track, double cutHere, boolean next) {

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     //compile 'life.knowledge4:k4l-video-trimmer:0.1-SNAPSHOT'
     compile project(':k4l-video-trimmer')
     compile 'com.android.support:appcompat-v7:24.0.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-alpha2'
+    //compile 'com.android.support.constraint:constraint-layout:1.0.0-alpha2'
     testCompile 'junit:junit:4.12'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
     androidTestCompile 'com.android.support.test:runner:0.5'

--- a/sample-app/src/main/java/life/knowledge4/videotrimmersample/TrimmerActivity.java
+++ b/sample-app/src/main/java/life/knowledge4/videotrimmersample/TrimmerActivity.java
@@ -1,5 +1,6 @@
 package life.knowledge4.videotrimmersample;
 
+import android.app.ProgressDialog;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -12,6 +13,7 @@ import life.knowledge4.videotrimmer.interfaces.OnTrimVideoListener;
 public class TrimmerActivity extends AppCompatActivity implements OnTrimVideoListener {
 
     private K4LVideoTrimmer mVideoTrimmer;
+    private ProgressDialog mProgressDialog;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -25,6 +27,10 @@ public class TrimmerActivity extends AppCompatActivity implements OnTrimVideoLis
             path = extraIntent.getStringExtra(MainActivity.EXTRA_VIDEO_PATH);
         }
 
+        //setting progressbar
+        mProgressDialog = new ProgressDialog(this);
+        mProgressDialog.setCancelable(false);
+        mProgressDialog.setMessage("Trimming your video...");
 
         mVideoTrimmer = ((K4LVideoTrimmer) findViewById(R.id.timeLine));
         if (mVideoTrimmer != null) {
@@ -37,7 +43,14 @@ public class TrimmerActivity extends AppCompatActivity implements OnTrimVideoLis
     }
 
     @Override
+    public void onTrimStarted() {
+        mProgressDialog.show();
+    }
+
+    @Override
     public void getResult(final Uri uri) {
+        mProgressDialog.cancel();
+
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -52,12 +65,15 @@ public class TrimmerActivity extends AppCompatActivity implements OnTrimVideoLis
 
     @Override
     public void cancelAction() {
+        mProgressDialog.cancel();
         mVideoTrimmer.destroy();
         finish();
     }
 
     @Override
     public void onError(final String message) {
+        mProgressDialog.cancel();
+
         runOnUiThread(new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
###### Fixes issue #.
- Adding onTrimStarted so that we can use this to open progress dialog while video is trimming in background
- Fixing NullPointerExcepion if OnTrimVideoListener is not set.
