### PR TITLE
Add watermark/sticker/text over video at specific time, location scale and rotation 

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+- [ ] I have verified there are no duplicate active or recent bugs, questions, or requests
+
+###### Include the following:
+ - k4l-video-trimmer version: `1.0.3`
+ - Device OS version: `6.0.1`
+ - Devide Manufacturer: `Motorola`
+ - Device Name: `G4 Plus`
+ 
+###### Reproduction Steps
+ 1.
+ 2.
+ 3.
+
+###### Expected Result
+
+###### Actual Result
+
+### Tell us what could be improved:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+###### Fixes issue #.
+- [ ] This pull request follows the coding standards
+
+###### This PR changes:
+ - 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,28 @@
   
   * Library - Android ICS 4.1+ (API 16)
   * Sample - Android ICS 4.1+ (API 16)
+  
+# Using SNAPSHOTS
+  
+ Add the sonatype snapshots repository.
+  ```
+  'https://oss.sonatype.org/content/repositories/snapshots/'
+  ```
+  Example: 
+  ```
+  repositories{
+    flatDir{
+        dirs 'libs'
+    }
+    maven {
+        url = 'https://oss.sonatype.org/content/repositories/snapshots/'
+    }
+  }
+  ```
+  Then:
+  ```
+  compile 'life.knowledge4:k4l-video-trimmer:1.1.3-SNAPSHOT'
+  ```
 
 ## Collaboration
 There are many ways of improving and adding more features, so feel free to collaborate with ideas, issues and/or pull requests.  

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha6'
+        classpath 'com.android.tools.build:gradle:2.2.0-alpha7'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha3'
+        classpath 'com.android.tools.build:gradle:2.2.0-alpha4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha4'
+        classpath 'com.android.tools.build:gradle:2.2.0-alpha6'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 }
 
 project.ext{
-    VERSION_NAME='1.1-SNAPSHOT'
+    VERSION_NAME='1.1.1-SNAPSHOT'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 }
 
 project.ext{
-    VERSION_NAME='1.0-SNAPSHOT'
+    VERSION_NAME='1.1-SNAPSHOT'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 }
 
 project.ext{
-    VERSION_NAME='1.1.2-SNAPSHOT'
+    VERSION_NAME='1.1.3-SNAPSHOT'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 }
 
 project.ext{
-    VERSION_NAME='1.1.1-SNAPSHOT'
+    VERSION_NAME='1.1.2-SNAPSHOT'
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Sun Aug 07 15:14:15 BRT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/k4l-video-trimmer/build.gradle
+++ b/k4l-video-trimmer/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply from: '../mavenpush.gradle'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 24
     buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -22,10 +22,10 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.android.support:appcompat-v7:24.0.0'
     compile 'com.googlecode.mp4parser:isoparser:1.1.20'
     testCompile 'junit:junit:4.12'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
     androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support:support-annotations:23.4.0'
+    androidTestCompile 'com.android.support:support-annotations:24.0.0'
 }

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
@@ -316,6 +316,7 @@ public class K4LVideoTrimmer extends FrameLayout {
     }
 
     private void onCancelClicked() {
+        mVideoView.stopPlayback();
         mOnTrimVideoListener.cancelAction();
     }
 

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
@@ -50,6 +50,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
+import life.knowledge4.videotrimmer.interfaces.OnK4LVideoListener;
 import life.knowledge4.videotrimmer.interfaces.OnProgressVideoListener;
 import life.knowledge4.videotrimmer.interfaces.OnRangeSeekBarListener;
 import life.knowledge4.videotrimmer.interfaces.OnTrimVideoListener;
@@ -88,6 +89,8 @@ public class K4LVideoTrimmer extends FrameLayout {
     private List<OnProgressVideoListener> mListeners;
 
     private OnTrimVideoListener mOnTrimVideoListener;
+    private OnK4LVideoListener mOnK4LVideoListener;
+
     private int mDuration = 0;
     private int mTimeVideo = 0;
     private int mStartPosition = 0;
@@ -317,7 +320,9 @@ public class K4LVideoTrimmer extends FrameLayout {
 
     private void onCancelClicked() {
         mVideoView.stopPlayback();
-        mOnTrimVideoListener.cancelAction();
+        if (mOnTrimVideoListener != null) {
+            mOnTrimVideoListener.cancelAction();
+        }
     }
 
     private String getDestinationPath() {
@@ -390,6 +395,10 @@ public class K4LVideoTrimmer extends FrameLayout {
 
         setTimeFrames();
         setTimeVideo(0);
+
+        if (mOnK4LVideoListener != null) {
+            mOnK4LVideoListener.onVideoPrepared();
+        }
     }
 
     private void setSeekBarPosition() {
@@ -509,6 +518,16 @@ public class K4LVideoTrimmer extends FrameLayout {
     @SuppressWarnings("unused")
     public void setOnTrimVideoListener(OnTrimVideoListener onTrimVideoListener) {
         mOnTrimVideoListener = onTrimVideoListener;
+    }
+
+    /**
+     * Listener for some {@link VideoView} events
+     *
+     * @param onK4LVideoListener interface for events
+     */
+    @SuppressWarnings("unused")
+    public void setOnK4LVideoListener(OnK4LVideoListener onK4LVideoListener) {
+        mOnK4LVideoListener = onK4LVideoListener;
     }
 
     /**

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
@@ -166,6 +166,14 @@ public class K4LVideoTrimmer extends FrameLayout {
                 }
         );
 
+        mVideoView.setOnErrorListener(new MediaPlayer.OnErrorListener() {
+            @Override
+            public boolean onError(MediaPlayer mediaPlayer, int what, int extra) {
+                mOnTrimVideoListener.onError("Something went wrong reason : " + what);
+                return false;
+            }
+        });
+
         mVideoView.setOnTouchListener(new View.OnTouchListener() {
             @Override
             public boolean onTouch(View v, @NonNull MotionEvent event) {

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
@@ -169,7 +169,8 @@ public class K4LVideoTrimmer extends FrameLayout {
         mVideoView.setOnErrorListener(new MediaPlayer.OnErrorListener() {
             @Override
             public boolean onError(MediaPlayer mediaPlayer, int what, int extra) {
-                mOnTrimVideoListener.onError("Something went wrong reason : " + what);
+                if (mOnTrimVideoListener != null)
+                    mOnTrimVideoListener.onError("Something went wrong reason : " + what);
                 return false;
             }
         });
@@ -256,7 +257,8 @@ public class K4LVideoTrimmer extends FrameLayout {
 
     private void onSaveClicked() {
         if (mStartPosition <= 0 && mEndPosition >= mDuration) {
-            mOnTrimVideoListener.getResult(mSrc);
+            if (mOnTrimVideoListener != null)
+                mOnTrimVideoListener.getResult(mSrc);
         } else {
             mPlayView.setVisibility(View.VISIBLE);
             mVideoView.pause();
@@ -275,6 +277,10 @@ public class K4LVideoTrimmer extends FrameLayout {
                     mStartPosition -= (MIN_TIME_FRAME - mTimeVideo);
                 }
             }
+
+            //notify that video trimming started
+            if (mOnTrimVideoListener != null)
+                mOnTrimVideoListener.onTrimStarted();
 
             BackgroundExecutor.execute(
                     new BackgroundExecutor.Task("", 0L, "") {

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
@@ -130,7 +130,7 @@ public class K4LVideoTrimmer extends FrameLayout {
         mListeners.add(new OnProgressVideoListener() {
             @Override
             public void updateProgress(int time, int max, float scale) {
-                K4LVideoTrimmer.this.updateVideoProgress(time);
+                updateVideoProgress(time);
             }
         });
         mListeners.add(mVideoProgressIndicator);

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/interfaces/OnK4LVideoListener.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/interfaces/OnK4LVideoListener.java
@@ -1,0 +1,29 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016 Knowledge, education for life.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package life.knowledge4.videotrimmer.interfaces;
+
+public interface OnK4LVideoListener {
+
+    void onVideoPrepared();
+}

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/interfaces/OnTrimVideoListener.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/interfaces/OnTrimVideoListener.java
@@ -27,6 +27,8 @@ import android.net.Uri;
 
 public interface OnTrimVideoListener {
 
+    void onTrimStarted();
+
     void getResult(final Uri uri);
 
     void cancelAction();

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/interfaces/OnTrimVideoListener.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/interfaces/OnTrimVideoListener.java
@@ -30,4 +30,6 @@ public interface OnTrimVideoListener {
     void getResult(final Uri uri);
 
     void cancelAction();
+
+    void onError(final String message);
 }

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/utils/TrimVideoUtils.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/utils/TrimVideoUtils.java
@@ -137,7 +137,8 @@ public class TrimVideoUtils {
 
         fc.close();
         fos.close();
-        callback.getResult(Uri.parse(dst.toString()));
+        if (callback != null)
+            callback.getResult(Uri.parse(dst.toString()));
     }
 
     private static double correctTimeToSyncSample(@NonNull Track track, double cutHere, boolean next) {

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/utils/TrimVideoUtils.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/utils/TrimVideoUtils.java
@@ -43,6 +43,7 @@ import java.nio.channels.FileChannel;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Formatter;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -168,5 +169,20 @@ public class TrimVideoUtils {
             previous = timeOfSyncSample;
         }
         return timeOfSyncSamples[timeOfSyncSamples.length - 1];
+    }
+
+    public static String stringForTime(int timeMs) {
+        int totalSeconds = timeMs / 1000;
+
+        int seconds = totalSeconds % 60;
+        int minutes = (totalSeconds / 60) % 60;
+        int hours = totalSeconds / 3600;
+
+        Formatter mFormatter = new Formatter();
+        if (hours > 0) {
+            return mFormatter.format("%d:%02d:%02d", hours, minutes, seconds).toString();
+        } else {
+            return mFormatter.format("%02d:%02d", minutes, seconds).toString();
+        }
     }
 }

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/utils/TrimVideoUtils.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/utils/TrimVideoUtils.java
@@ -54,7 +54,6 @@ public class TrimVideoUtils {
 
     private static final String TAG = TrimVideoUtils.class.getSimpleName();
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     public static void startTrim(@NonNull File src, @NonNull String dst, long startMs, long endMs, @NonNull OnTrimVideoListener callback) throws IOException {
         final String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(new Date());
         final String fileName = "MP4_" + timeStamp + ".mp4";
@@ -66,7 +65,6 @@ public class TrimVideoUtils {
         genVideoUsingMp4Parser(src, file, startMs, endMs, callback);
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     private static void genVideoUsingMp4Parser(@NonNull File src, @NonNull File dst, long startMs, long endMs, @NonNull OnTrimVideoListener callback) throws IOException {
         // NOTE: Switched to using FileDataSourceViaHeapImpl since it does not use memory mapping (VM).
         // Otherwise we get OOM with large movie files.

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/view/Thumb.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/view/Thumb.java
@@ -35,6 +35,9 @@ import life.knowledge4.videotrimmer.R;
 
 public class Thumb {
 
+    public static final int LEFT = 0;
+    public static final int RIGHT = 1;
+
     private int mIndex;
     private float mVal;
     private float mPos;

--- a/k4l-video-trimmer/src/main/res/layout/view_time_line.xml
+++ b/k4l-video-trimmer/src/main/res/layout/view_time_line.xml
@@ -111,7 +111,7 @@
         android:id="@+id/timeText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignTop="@id/layout"
+        android:layout_alignTop="@+id/layout"
         android:visibility="gone">
 
         <TextView

--- a/k4l-video-trimmer/src/main/res/layout/view_time_line.xml
+++ b/k4l-video-trimmer/src/main/res/layout/view_time_line.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
 
     <RelativeLayout
         android:id="@+id/layout_surface_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@+id/timeText"
+        android:layout_above="@+id/layout"
         android:background="@android:color/black"
         android:gravity="center"
         android:orientation="vertical">
@@ -18,7 +18,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_centerHorizontal="true"
-            android:layout_centerVertical="true" />
+            android:layout_centerVertical="true"/>
 
         <ImageView
             android:id="@+id/icon_video_play"
@@ -26,45 +26,7 @@
             android:layout_height="wrap_content"
             android:layout_centerHorizontal="true"
             android:layout_centerVertical="true"
-            android:background="@drawable/play_button" />
-
-    </RelativeLayout>
-
-
-    <RelativeLayout
-        android:id="@+id/timeText"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_above="@+id/layout"
-        android:orientation="horizontal"
-        android:visibility="gone">
-
-        <TextView
-            android:id="@+id/textSize"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:textColor="@android:color/white" />
-
-        <TextView
-            android:id="@+id/textTimeSelection"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_toEndOf="@+id/textSize"
-            android:layout_toLeftOf="@+id/textTime"
-            android:layout_toRightOf="@+id/textSize"
-            android:layout_toStartOf="@+id/textTime"
-            android:gravity="center"
-            android:textColor="@android:color/white" />
-
-        <TextView
-            android:id="@+id/textTime"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:textColor="@android:color/white" />
+            android:background="@drawable/play_button"/>
 
     </RelativeLayout>
 
@@ -80,33 +42,35 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
+            android:max="1000"
             android:progressDrawable="@android:color/transparent"
-            android:thumb="@drawable/apptheme_text_select_handle_middle" />
+            android:secondaryProgress="0"
+            android:thumb="@drawable/apptheme_text_select_handle_middle"/>
 
         <life.knowledge4.videotrimmer.view.ProgressBarView
             android:id="@+id/timeVideoView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/handlerTop" />
+            android:layout_below="@id/handlerTop"/>
 
         <life.knowledge4.videotrimmer.view.TimeLineView
             android:id="@+id/timeLineView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/timeVideoView" />
+            android:layout_below="@+id/timeVideoView"/>
 
         <life.knowledge4.videotrimmer.view.RangeSeekBarView
             android:id="@+id/timeLineBar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignTop="@+id/timeLineView" />
+            android:layout_alignTop="@+id/timeLineView"/>
 
         <View
             android:id="@+id/lineTop"
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:layout_below="@+id/timeLineBar"
-            android:background="@color/line_button" />
+            android:background="@color/line_button"/>
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -121,14 +85,14 @@
                 android:layout_weight="1"
                 android:background="@drawable/black_button_background"
                 android:text="@string/cancel"
-                android:textColor="@android:color/white" />
+                android:textColor="@android:color/white"/>
 
             <View
                 android:layout_width="1dp"
                 android:layout_height="match_parent"
                 android:layout_marginBottom="5dp"
                 android:layout_marginTop="5dp"
-                android:background="@color/line_button" />
+                android:background="@color/line_button"/>
 
             <Button
                 android:id="@+id/btSave"
@@ -137,9 +101,47 @@
                 android:layout_weight="1"
                 android:background="@drawable/black_button_background"
                 android:text="@string/save"
-                android:textColor="@android:color/white" />
+                android:textColor="@android:color/white"/>
 
         </LinearLayout>
 
     </RelativeLayout>
+
+    <RelativeLayout
+        android:id="@+id/timeText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignTop="@id/layout"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/textSize"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:textColor="@android:color/white"/>
+
+        <TextView
+            android:id="@+id/textTimeSelection"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_toEndOf="@+id/textSize"
+            android:layout_toLeftOf="@+id/textTime"
+            android:layout_toRightOf="@+id/textSize"
+            android:layout_toStartOf="@+id/textTime"
+            android:gravity="center"
+            android:textColor="@android:color/white"/>
+
+        <TextView
+            android:id="@+id/textTime"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            android:textColor="@android:color/white"/>
+
+    </RelativeLayout>
+
+
 </RelativeLayout>

--- a/k4l-video-trimmer/src/main/res/layout/view_time_line.xml
+++ b/k4l-video-trimmer/src/main/res/layout/view_time_line.xml
@@ -51,7 +51,7 @@
             android:id="@+id/timeVideoView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@id/handlerTop"/>
+            android:layout_below="@+id/handlerTop"/>
 
         <life.knowledge4.videotrimmer.view.TimeLineView
             android:id="@+id/timeLineView"

--- a/k4l-video-trimmer/src/main/res/values-es/strings.xml
+++ b/k4l-video-trimmer/src/main/res/values-es/strings.xml
@@ -1,0 +1,7 @@
+<resources>
+  <string name="cancel">Cancelar</string>
+  <string name="save">Guardar</string>
+  <string name="short_seconds">sec</string>
+  <string name="megabyte">MB</string>
+  <string name="kilobyte">KB</string>
+</resources>

--- a/k4l-video-trimmer/src/main/res/values-pt-rBR/strings.xml
+++ b/k4l-video-trimmer/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,7 @@
+<resources>
+  <string name="cancel">Cancelar</string>
+  <string name="save">Salvar</string>
+  <string name="short_seconds">sec</string>
+  <string name="megabyte">MB</string>
+  <string name="kilobyte">KB</string>
+</resources>

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     //compile 'life.knowledge4:k4l-video-trimmer:0.1-SNAPSHOT'
     compile project(':k4l-video-trimmer')
     compile 'com.android.support:appcompat-v7:24.0.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-alpha2'
+    //compile 'com.android.support.constraint:constraint-layout:1.0.0-alpha2'
     testCompile 'junit:junit:4.12'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
     androidTestCompile 'com.android.support.test:runner:0.5'

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -33,7 +33,6 @@ dependencies {
     //compile 'life.knowledge4:k4l-video-trimmer:0.1-SNAPSHOT'
     compile project(':k4l-video-trimmer')
     compile 'com.android.support:appcompat-v7:24.0.0'
-    //compile 'com.android.support.constraint:constraint-layout:1.0.0-alpha2'
     testCompile 'junit:junit:4.12'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
     androidTestCompile 'com.android.support.test:runner:0.5'

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 24
     buildToolsVersion "23.0.3"
     defaultConfig {
         applicationId "life.knowledge4.videocroppersample"
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -32,10 +32,10 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     //compile 'life.knowledge4:k4l-video-trimmer:0.1-SNAPSHOT'
     compile project(':k4l-video-trimmer')
-    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.android.support:appcompat-v7:24.0.0'
     compile 'com.android.support.constraint:constraint-layout:1.0.0-alpha2'
     testCompile 'junit:junit:4.12'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
     androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support:support-annotations:23.4.0'
+    androidTestCompile 'com.android.support:support-annotations:24.0.0'
 }

--- a/sample-app/src/main/java/life/knowledge4/videotrimmersample/TrimmerActivity.java
+++ b/sample-app/src/main/java/life/knowledge4/videotrimmersample/TrimmerActivity.java
@@ -1,5 +1,6 @@
 package life.knowledge4.videotrimmersample;
 
+import android.app.ProgressDialog;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -12,6 +13,7 @@ import life.knowledge4.videotrimmer.interfaces.OnTrimVideoListener;
 public class TrimmerActivity extends AppCompatActivity implements OnTrimVideoListener {
 
     private K4LVideoTrimmer mVideoTrimmer;
+    private ProgressDialog mProgressDialog;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -25,6 +27,10 @@ public class TrimmerActivity extends AppCompatActivity implements OnTrimVideoLis
             path = extraIntent.getStringExtra(MainActivity.EXTRA_VIDEO_PATH);
         }
 
+        //setting progressbar
+        mProgressDialog = new ProgressDialog(this);
+        mProgressDialog.setCancelable(false);
+        mProgressDialog.setMessage("Trimming your video...");
 
         mVideoTrimmer = ((K4LVideoTrimmer) findViewById(R.id.timeLine));
         if (mVideoTrimmer != null) {
@@ -37,7 +43,14 @@ public class TrimmerActivity extends AppCompatActivity implements OnTrimVideoLis
     }
 
     @Override
+    public void onTrimStarted() {
+        mProgressDialog.show();
+    }
+
+    @Override
     public void getResult(final Uri uri) {
+        mProgressDialog.cancel();
+
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -52,12 +65,15 @@ public class TrimmerActivity extends AppCompatActivity implements OnTrimVideoLis
 
     @Override
     public void cancelAction() {
+        mProgressDialog.cancel();
         mVideoTrimmer.destroy();
         finish();
     }
 
     @Override
     public void onError(final String message) {
+        mProgressDialog.cancel();
+
         runOnUiThread(new Runnable() {
             @Override
             public void run() {

--- a/sample-app/src/main/java/life/knowledge4/videotrimmersample/TrimmerActivity.java
+++ b/sample-app/src/main/java/life/knowledge4/videotrimmersample/TrimmerActivity.java
@@ -8,9 +8,10 @@ import android.support.v7.app.AppCompatActivity;
 import android.widget.Toast;
 
 import life.knowledge4.videotrimmer.K4LVideoTrimmer;
+import life.knowledge4.videotrimmer.interfaces.OnK4LVideoListener;
 import life.knowledge4.videotrimmer.interfaces.OnTrimVideoListener;
 
-public class TrimmerActivity extends AppCompatActivity implements OnTrimVideoListener {
+public class TrimmerActivity extends AppCompatActivity implements OnTrimVideoListener, OnK4LVideoListener {
 
     private K4LVideoTrimmer mVideoTrimmer;
     private ProgressDialog mProgressDialog;
@@ -30,12 +31,13 @@ public class TrimmerActivity extends AppCompatActivity implements OnTrimVideoLis
         //setting progressbar
         mProgressDialog = new ProgressDialog(this);
         mProgressDialog.setCancelable(false);
-        mProgressDialog.setMessage("Trimming your video...");
+        mProgressDialog.setMessage(getString(R.string.trimming_progress));
 
         mVideoTrimmer = ((K4LVideoTrimmer) findViewById(R.id.timeLine));
         if (mVideoTrimmer != null) {
             mVideoTrimmer.setMaxDuration(10);
             mVideoTrimmer.setOnTrimVideoListener(this);
+            mVideoTrimmer.setOnK4LVideoListener(this);
             //mVideoTrimmer.setDestinationPath("/storage/emulated/0/DCIM/CameraCustom/");
             mVideoTrimmer.setVideoURI(Uri.parse(path));
             mVideoTrimmer.setVideoInformationVisibility(true);
@@ -78,6 +80,16 @@ public class TrimmerActivity extends AppCompatActivity implements OnTrimVideoLis
             @Override
             public void run() {
                 Toast.makeText(TrimmerActivity.this, message, Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    @Override
+    public void onVideoPrepared() {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                Toast.makeText(TrimmerActivity.this, "onVideoPrepared", Toast.LENGTH_SHORT).show();
             }
         });
     }

--- a/sample-app/src/main/java/life/knowledge4/videotrimmersample/TrimmerActivity.java
+++ b/sample-app/src/main/java/life/knowledge4/videotrimmersample/TrimmerActivity.java
@@ -32,6 +32,7 @@ public class TrimmerActivity extends AppCompatActivity implements OnTrimVideoLis
             mVideoTrimmer.setOnTrimVideoListener(this);
             //mVideoTrimmer.setDestinationPath("/storage/emulated/0/DCIM/CameraCustom/");
             mVideoTrimmer.setVideoURI(Uri.parse(path));
+            mVideoTrimmer.setVideoInformationVisibility(true);
         }
     }
 

--- a/sample-app/src/main/java/life/knowledge4/videotrimmersample/TrimmerActivity.java
+++ b/sample-app/src/main/java/life/knowledge4/videotrimmersample/TrimmerActivity.java
@@ -55,4 +55,14 @@ public class TrimmerActivity extends AppCompatActivity implements OnTrimVideoLis
         mVideoTrimmer.destroy();
         finish();
     }
+
+    @Override
+    public void onError(final String message) {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                Toast.makeText(TrimmerActivity.this, message, Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
 }

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -14,4 +14,5 @@
         \n\n# Works with gallery and recorded videos
     </string>
     <string name="pick_a_video">Select or record a a video below to try it out:</string>
+    <string name="trimming_progress">Trimming your video...</string>
 </resources>


### PR DESCRIPTION
###### Fixes issue #.
- [ ] This pull request follows the coding standards
Add watermark/sticker/text over video at specific time, location scale and rotation 

Can we add a feature for this project to be able to add watermark/ text on video between a specific time range, which can be rotated , scaled, and positioned according to user inputs, 


###### This PR changes:
 - 
I am an android developer and came across this library when looking for trimming videos, now we need to add stickers, for that I have came across  this 
http://stackoverflow.com/questions/15475805/how-to-handle-stickers-with-resize-and-rotate-functionality/35739505#35739505

and the FFMpeg command would be this, 
 `String[] complexCommand2 = {"-y", "-i", videoFilePath, "-i", imagepath, "-filter_complex","[1:v] format=bgra, rotate=30*PI/180:c=none:ow=rotw(30*PI/180):oh=roth(30*PI/180) [rotate];[rotate]scale=50:50[scale];[0:v][scale] overlay=40:10","-codec:a","copy", outputFilePath};`

however , my problem arises how to pass the user input data from android to the ffmpeg command , If this feature is added to this library it would make it better 
 