### PR TITLE
for trimming small length videos

### DIFF
--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/utils/TrimVideoUtils.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/utils/TrimVideoUtils.java
@@ -91,8 +91,8 @@ public class TrimVideoUtils {
 
                     throw new RuntimeException("The startTime has already been corrected by another track with SyncSample. Not Supported.");
                 }
-                startTime1 = correctTimeToSyncSample(track, startTime1, false);
-                endTime1 = correctTimeToSyncSample(track, endTime1, true);
+//                 startTime1 = correctTimeToSyncSample(track, startTime1, false);
+//                 endTime1 = correctTimeToSyncSample(track, endTime1, true);
                 timeCorrected = true;
             }
         }


### PR DESCRIPTION
Small videos start from 0 seconds even after trimmed from another position

###### Fixes issue #.
- [x] This pull request follows the coding standards

###### This PR changes:
 - 